### PR TITLE
add the $layers_dir argument to bin/build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## master
+- add the $layers_dir argument to bin/build ([#3](https://github.com/heroku/nodejs-typescript-buildpack/pull/3))

--- a/bin/build
+++ b/bin/build
@@ -3,6 +3,8 @@
 set -e
 set -o pipefail
 
+layers_dir=$1
+
 bp_dir=$(cd "$(dirname "$0")"/..; pwd)
 
 # shellcheck source=/dev/null


### PR DESCRIPTION
# Description

Adds the argument of $layers_dir to be used in the build scripts.

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
