### PR TITLE
check if tsc binary is present in the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## master
 - add the $layers_dir argument to bin/build ([#3](https://github.com/heroku/nodejs-typescript-buildpack/pull/3))
 - detect outDir directory from tsconfig.json ([#4](https://github.com/heroku/nodejs-typescript-buildpack/pull/4))
+- check if tsc binary is present in the build ([#6](https://github.com/heroku/nodejs-typescript-buildpack/pull/6))

--- a/bin/build
+++ b/bin/build
@@ -6,6 +6,7 @@ set -o pipefail
 layers_dir=$1
 
 bp_dir=$(cd "$(dirname "$0")"/..; pwd)
+build_dir=$(pwd)
 
 # shellcheck source=/dev/null
 source "$bp_dir/lib/build.sh"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -14,3 +14,9 @@ detect_out_dir() {
 
   [[ -f "$build_dir/$out_dir" ]]
 }
+
+check_tsc_binary() {
+  local build_dir=$1
+
+  [[ -f "$build_dir/node_modules/typescript/bin/tsc" ]]
+}

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -32,3 +32,27 @@ describe "lib/build.sh"
       assert equal "$?" 0
     end
   end
+
+  describe "check_tsc_binary"
+    it "exits with 1 if tsc binary does not exist"
+      project_dir=$(create_temp_project_dir)
+
+      set +e
+      check_tsc_binary "$project_dir"
+      loc_var=$?
+      set -e
+
+      assert equal "$loc_var" 1
+    end
+
+    it "exits with 0 if tsc binary exists"
+      project_dir=$(create_temp_project_dir)
+      touch "$project_dir/node_modules/typescript/bin/tsc"
+
+      check_tsc_binary "$project_dir"
+
+      assert equal "$?" 0
+    end
+  end
+
+end


### PR DESCRIPTION
# Description

Add method in build.sh to check whether the tsc binary is present in the build to be used

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
