### PR TITLE
add ts binary to PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add the $layers_dir argument to bin/build ([#3](https://github.com/heroku/nodejs-typescript-buildpack/pull/3))
 - detect outDir directory from tsconfig.json ([#4](https://github.com/heroku/nodejs-typescript-buildpack/pull/4))
 - check if tsc binary is present in the build ([#6](https://github.com/heroku/nodejs-typescript-buildpack/pull/6))
+- add typescript binary to PATH ([#7](https://github.com/heroku/nodejs-typescript-buildpack/pull/7))

--- a/bin/build
+++ b/bin/build
@@ -10,3 +10,7 @@ build_dir=$(pwd)
 
 # shellcheck source=/dev/null
 source "$bp_dir/lib/build.sh"
+
+if check_tsc_binary "$build_dir" ; then
+  export PATH=./node_modules/typescript/bin:$PATH
+fi


### PR DESCRIPTION
# Description

Add the TypeScript binary from node_modules to PATH, so the binaries can be used in the build

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
