### PR TITLE
Add heroku-20 support with stack tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,32 @@
 version: 2.1
 orbs:
-  shellcheck: circleci/shellcheck@1.3.15
-workflows:
-  build-and-test:
-    jobs:
-      - shellcheck/check
-      - run-unit-tests
+  shellcheck: circleci/shellcheck@1.3.16
 jobs:
-  run-unit-tests:
+  unit-test-heroku-stack:
+    parameters:
+      stack:
+        type: "string"
+        default: "heroku-20"
     docker:
-      - image: heroku/pack-runner:latest
+      - image: "danielleadams/shpec-<<parameters.stack>>:latest"
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
-          name: Run unit tests
-          command: make docker-unit-test
+          name: Shpec unit tests on <<parameters.stack>>
+          command: make unit-test
+workflows:
+  version: 2
+  run-tests:
+    jobs:
+      - unit-test-heroku-stack:
+          name: "Unit tests for heroku-20"
+          stack: "heroku-20"
+      - unit-test-heroku-stack:
+          name: "Unit tests for heroku-18"
+          stack: "heroku-18"
+      - unit-test-heroku-stack:
+          name: "Unit tests for heroku-16"
+          stack: "heroku-16"
+      - shellcheck/check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## main
+- Add heroku-20 support and stack-specific tests ([#13](https://github.com/heroku/nodejs-typescript-buildpack/pull/13))
 
 ## v0.1.0
 ### Added

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -9,4 +9,7 @@ name = "TypeScript Buildpack"
 id = "heroku-18"
 
 [[stacks]]
+id = "heroku-20"
+
+[[stacks]]
 id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
# Description

This pull request adds heroku-20 to the `buildpack.toml`. It also breaks down unit tests and (new) integration tests by stack to be run on Circle. The Circle config is copied over from what we have on heroku/nodejs-engine {[current](https://github.com/heroku/nodejs-engine-buildpack/blob/main/.circleci/config.yml) and https://github.com/heroku/nodejs-engine-buildpack/pull/60).

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
